### PR TITLE
Add Node.js ping example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ curl -H "Authorization: Bearer <API_KEY>" https://api.japer.io/v1/x/ping
 healthy
 ```
 
+### Node Example
+
+A sample script using Node's `https` module is available in `examples/node/ping.js`.
+Execute it with your API key:
+
+```bash
+NODE_API_KEY=<YOUR_KEY> node examples/node/ping.js
+```
+
 ## Accessing the JAPER API
 
 - Base URL: `https://api.japer.io`

--- a/examples/node/ping.js
+++ b/examples/node/ping.js
@@ -1,0 +1,30 @@
+const https = require('https');
+
+const apiKey = process.env.NODE_API_KEY;
+if (!apiKey) {
+  console.error('NODE_API_KEY environment variable is required');
+  process.exit(1);
+}
+
+const options = {
+  hostname: 'api.japer.io',
+  path: '/v1/x/ping',
+  method: 'GET',
+  headers: {
+    'Authorization': `Bearer ${apiKey}`,
+  },
+};
+
+const req = https.request(options, res => {
+  let data = '';
+  res.on('data', chunk => data += chunk);
+  res.on('end', () => {
+    console.log(data.trim());
+  });
+});
+
+req.on('error', err => {
+  console.error(err.message);
+});
+
+req.end();


### PR DESCRIPTION
## Summary
- add a Node example under `examples/node/ping.js`
- document how to run the new Node sample

## Testing
- `node examples/node/ping.js` *(fails: NODE_API_KEY required)*

------
https://chatgpt.com/codex/tasks/task_b_685b37d501ec8325bb96075573cdbd9e